### PR TITLE
👋 About page failed to deployment

### DIFF
--- a/node_modules/.bin/gulp
+++ b/node_modules/.bin/gulp
@@ -1,1 +1,0 @@
-gulpfile.js


### PR DESCRIPTION
👋 I come across to see the post https://github.community/t/github-pages-bot-build-failure-please-help/222815 (looks like it get deleted), it's due to the hard link pointed file is missing.

Trying to delete https://github.com/maggie-and-joe/maggie-and-joe.github.io/blob/master/node_modules/.bin/gulp should fix the case.